### PR TITLE
Add a table of contents to the flags page

### DIFF
--- a/source/regions/flags.rst
+++ b/source/regions/flags.rst
@@ -27,6 +27,11 @@ List flags by using the "flags" command::
 
 The output of this command is interactive in-game. Click flag values to change them, and the arrows at the bottom to navigate through pages.
 
+.. contents::
+    :local:
+    :backlinks: none
+    :depth: 2
+
 .. _region-groups:
 
 Region Groups

--- a/source/regions/flags.rst
+++ b/source/regions/flags.rst
@@ -55,7 +55,7 @@ It is **not** possible to set the same flag to different values for more than on
     When there are multiple overlapping regions, a player must be a member of the region *on which the flag is set* or *on one of the region's child regions* (when region inheritance is involved). This is explained further in :doc:`priorities`.
 
 .. tip::
-    The entry and exit flags default to "non-member", meaning setting them to "deny" will prevent non-members from entering/exiting the region. The teleport and spawn location flags default to "members", which means that only members can take advantage of them by default. All other flags provided by WorldGuard default to "everyone".
+    The ``entry`` and ``exit`` flags default to "non-member", meaning setting them to "deny" will prevent non-members from entering/exiting the region. The ``teleport`` and ``spawn`` location flags default to "members", which means that only members can take advantage of them by default. All other flags provided by WorldGuard default to "everyone".
 
 Types of Flags
 ==============
@@ -77,7 +77,7 @@ Each flag is of a certain type that determines what kind of values it may take. 
 Internally, there are more types, but it should generally not be of concern.
 
 .. tip::
-    Most string flags will accept ``\n`` as a newline (for example, to send multiple lines via greeting/farewell, or a title and subtitle via greeting-title and farewell-title).
+    Most string flags will accept ``\n`` as a newline (for example, to send multiple lines via ``greeting``/``farewell``, or a title and subtitle via ``greeting-title`` and ``farewell-title``).
 
     They may also accept color codes, either in the old style ``&[0-9a-f]`` or ```[RrYyGgCcBbPp012w]`` for dark-red, red, dark yellow, yellow, etc., and ``[&`][klmnox]`` for obfuscated, bold, strikethrough, underline, and italic text.
 
@@ -85,7 +85,7 @@ Internally, there are more types, but it should generally not be of concern.
 
 .. topic:: Example: Using string formatting options
 
-    Setting spawn's greeting-title to a fancy welcome message::
+    Setting spawn's ``greeting-title`` to a fancy welcome message::
 
         /rg flag spawn greeting-title `bWelcome to spawn!\n`YEnjoy your stay in `g`n%world%`x, `C%name%`Y!
 
@@ -170,7 +170,7 @@ Protection-Related
     firework-damage,state,Whether fireworks can deal damage to entities
 
 .. warning::
-    None of these flags are player-specific. For example, the block-break flag, if set to deny, **prevents pistons from breaking blocks**.
+    None of these flags are player-specific. For example, the ``block-break`` flag, if set to deny, **prevents pistons from breaking blocks**.
 
     To understand why, consider the fact that players can fling TNT into a region from outside, or a player can build an inchworm piston machine that moves into another region. While these actions were caused by a player, realistically attempting to figure which player built the TNT cannon or used it is much more difficult. However, you still want to prevent someone from blowing up spawn with a TNT cannon.
 
@@ -277,13 +277,13 @@ Movement
     spawn,location,The location to teleport to when a player dies within the region
 
 .. tip::
-    As mentioned above, the teleport and spawn location flags default to "members", which means that only members can take advantage of them by default. Set the region group for the flag to change this.
+    As mentioned above, the ``teleport and ``spawn`` location flags default to "members", which means that only members can take advantage of them by default. Set the region group for the flag to change this.
 
 .. tip::
-    If overlapping regions have the same greeting or farewell flag, no message is sent when moving between these regions, e.g. if you enter one region while being in the other. This is also true, in a more general sense, of any player movement that does *not* result in the flag at the "from" and "to" locations changing.
+    If overlapping regions have the same ``greeting`` or ``farewell`` flag, no message is sent when moving between these regions, e.g. if you enter one region while being in the other. This is also true, in a more general sense, of any player movement that does *not* result in the flag at the "from" and "to" locations changing.
 
 .. warning::
-    The greeting and farewell message flags require that the "use player move event" option **not** be disabled in the :doc:`configuration <../config>`.
+    The ``greeting`` and ``farewell`` message flags require that the "use player move event" option **not** be disabled in the :doc:`configuration <../config>`.
 
 .. topic:: Example: Preventing non-members of a "secret_club" region from entering it
     

--- a/source/regions/flags.rst
+++ b/source/regions/flags.rst
@@ -277,7 +277,7 @@ Movement
     spawn,location,The location to teleport to when a player dies within the region
 
 .. tip::
-    As mentioned above, the ``teleport and ``spawn`` location flags default to "members", which means that only members can take advantage of them by default. Set the region group for the flag to change this.
+    As mentioned above, the ``teleport`` and ``spawn`` location flags default to "members", which means that only members can take advantage of them by default. Set the region group for the flag to change this.
 
 .. tip::
     If overlapping regions have the same ``greeting`` or ``farewell`` flag, no message is sent when moving between these regions, e.g. if you enter one region while being in the other. This is also true, in a more general sense, of any player movement that does *not* result in the flag at the "from" and "to" locations changing.


### PR DESCRIPTION
The flags page is long, and it's the type of page that you return to very often, so it's good to have a ToC. Maybe also add it to the Region Commands page?