### PR TITLE
Add new "common scenario" and some info on setting flags

### DIFF
--- a/source/regions/common-scenarios.rst
+++ b/source/regions/common-scenarios.rst
@@ -65,6 +65,27 @@ Make two regions:
 * One region would have ``exit=deny``.
 * The other region would border the side of the deny region, extending a bit outside, on the sides that you want to let players exit out of. This region would have ``exit-overide=true``.
 
+How can I let players move inside a region, but deny entry and exit (like in a jail)?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Similarly to the case above, make two regions:
+
+* One with ``entry=deny``.
+* Other, smaller region inside the first region, without any walls touching it, with flag ``entry=allow``. This region has to be a child of the larger region or have a higher priority.
+
+Example:
+
+    //pos1
+    //pos2
+    /rg define larger-region
+    /rg flag larger-region entry deny
+    //inset 2
+    /rg define smaller-region
+    /rg setparent smaller-region larger-region
+    /rg flag smaller-region entry allow
+
+Players that walk/fly very fast can sometimes pass through thin regions with denied entry, so if the smaller region doesn't have an outer wall made of non-passable blocks, it's good to make the bigger region at least 2 blocks larger in every direction (like in ``//outset 2``).
+
 How do I unprotect all enchantment tables?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/regions/common-scenarios.rst
+++ b/source/regions/common-scenarios.rst
@@ -73,7 +73,7 @@ Similarly to the case above, make two regions:
 * One with ``entry=deny``.
 * Other, smaller region inside the first region, without any walls touching it, with flag ``entry=allow``. This region has to be a child of the larger region or have a higher priority.
 
-Example:
+Example::
 
     //pos1
     //pos2

--- a/source/regions/flags.rst
+++ b/source/regions/flags.rst
@@ -27,6 +27,9 @@ List flags by using the "flags" command::
 
 The output of this command is interactive in-game. Click flag values to change them, and the arrows at the bottom to navigate through pages.
 
+.. tip::
+For some of the flags, if a player is inside the region when a flag is set, it won't take effect for that player until they leave the region and enter again, or rejoin the game. E.g. if you'd set the ``invincible`` flag to ``allow`` while being in the region, you would still take damage.
+
 .. contents::
     :local:
     :backlinks: none


### PR DESCRIPTION
This PR adds:
* a scenario for making a region with invisible walls (make two regions, bigger with entry deny, smaller with entry allow)
* information on what happens when you stand in a region and set flag like `invincible allow`, see [WorldGuard #1762](https://github.com/EngineHub/WorldGuard/issues/1762) (maybe it'd be good if this was expanded by someone who understands how does this work)