### PR TITLE
Update piston warning to mention nonplayer-protection-domains

### DIFF
--- a/source/regions/common-scenarios.rst
+++ b/source/regions/common-scenarios.rst
@@ -156,5 +156,5 @@ Did you set the ``build`` flag? You probably do not want to do that. Be sure to 
     /rg flag __global__ passthrough deny
 
 .. warning::
-    At this time, it is not possible for a piston to push from one region into another. This issue is tracked as `WORLDGUARD-3234 <https://github.com/EngineHub/WorldGuard/issues/1047>`_ on the issue tracker.
+    If you want a piston to push from one region into another, make sure both regions are in the same :ref:`nonplayer-protection-domain <flag-overrides>`.
 

--- a/source/regions/flags.rst
+++ b/source/regions/flags.rst
@@ -116,6 +116,8 @@ Flag Listing
 
 Flags are broken down into categories below.
 
+.. _flag-overrides:
+
 Overrides
 ~~~~~~~~~
 


### PR DESCRIPTION
https://github.com/EngineHub/WorldGuard/issues/1047 has been closed a while back, so I figured it might be about time to update this warning.
It now mentions nonplayer-protection-domains and links to the override-section of the flags page.