### PR TITLE
Update dev.py and conf.py to work with modern version

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 import http.server
 import queue
 import sys
@@ -79,7 +79,7 @@ def main():
 def rebuild():
     print("Performing docs build", file=sys.stderr)
     target = 'dirhtml'
-    exit_code = sphinx.cmd.build.main(argv=['-b', target, 'source', 'build/' + target])
+    exit_code = sphinx.cmd.build.main(['-b', target, 'source', 'build/' + target])
     if exit_code != 0:
         print("Sphinx exited with error code", exit_code, file=sys.stderr)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-watchdog
+watchdog==4.0.0
 -r source/requirements.txt

--- a/source/conf.py
+++ b/source/conf.py
@@ -35,9 +35,6 @@ extensions = [
     'sphinx.ext.ifconfig',
 ]
 
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
-
 # The suffix of source filenames.
 source_suffix = '.rst'
 
@@ -65,7 +62,7 @@ release = '7.0'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -140,11 +137,6 @@ html_theme_path, html_theme = detect_html_theme()
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
 #html_favicon = None
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -1,2 +1,2 @@
-sphinx
+Sphinx==7.3.7
 # enginehub.sphinx-youtube


### PR DESCRIPTION
Python on Windows doesn't ship `python3` anymore (plus I do hope that no one actually uses python2 anymore), and it seems like sphinx changed some things in newer versions as well
Removed some unconfigured config lines that caused warnings as well